### PR TITLE
Return actual error instead of generic error message (if possible)

### DIFF
--- a/src/app/Plugins/Registry/Services/location-registry-data.service.ts
+++ b/src/app/Plugins/Registry/Services/location-registry-data.service.ts
@@ -48,6 +48,7 @@ export class LocationRegistryDataService {
             console.error(
                 `Backend returned code ${error.status}, ` +
                 `body was: ${error.error}`);
+            return throwError('Error: ' + error.error.toString());
         }
         // return an observable with a user-facing error message
         return throwError('Something bad happened; please try again later.');

--- a/src/app/Plugins/Registry/Services/location-registry-data.service.ts
+++ b/src/app/Plugins/Registry/Services/location-registry-data.service.ts
@@ -38,17 +38,17 @@ export class LocationRegistryDataService {
     }
 
 
-    private handleError(error: HttpErrorResponse) {
-        if (error.error instanceof ErrorEvent) {
+    private handleError(errorResponse: HttpErrorResponse) {
+        if (errorResponse.error instanceof ErrorEvent) {
             // A client-side or network error occurred. Handle it accordingly.
-            console.error('An error occurred:', error.error.message);
+            console.error('An error occurred:', errorResponse.error.message);
         } else {
             // The backend returned an unsuccessful response code.
             // The response body may contain clues as to what went wrong,
             console.error(
-                `Backend returned code ${error.status}, ` +
-                `body was: ${error.error}`);
-            return throwError('Error: ' + error.error.toString());
+                `Backend returned code ${errorResponse.status}, ` +
+                `body was: ${errorResponse.error}`);
+            return throwError('Error: ' + errorResponse.error.toString());
         }
         // return an observable with a user-facing error message
         return throwError('Something bad happened; please try again later.');


### PR DESCRIPTION
This means that the actual error message is passed to the observer. The
observer can e.x. show the error message to the user.
Concrete example: If you already have a home-entity and try to set
another entity to ‘ home’, then the server returns an appropriate error
message that should be shown to the user